### PR TITLE
Fix broken app icon in Pop!_OS dock

### DIFF
--- a/com.fastmail.Fastmail.yml
+++ b/com.fastmail.Fastmail.yml
@@ -47,6 +47,7 @@ modules:
       - desktop-file-edit --set-key=Exec --set-value="fastmail %U" --set-icon=$FLATPAK_ID
         squashfs-root/fastmail.desktop
       - desktop-file-edit --set-key=Name --set-value=Fastmail squashfs-root/fastmail.desktop
+      - desktop-file-edit --set-key=StartupWMClass --set-value=com-fastmail-fastmail squashfs-root/fastmail.desktop
       - install -D squashfs-root/fastmail.desktop "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
       - |
         for size in 16 24 32 48 64 128 256 512; do


### PR DESCRIPTION
Electron 42 (shipped in Fastmail 1.3.0) transforms the `productName` via a `defaultDesktopName()` function that lowercases it and converts dots to hyphens. So `com.fastmail.Fastmail` becomes `com-fastmail-fastmail` as the Wayland xdg_toplevel app-id. COSMIC, the Pop!_OS desktop environment, receives that and can't match it to `com.fastmail.Fastmail.desktop`, so it shows a gear icon for the running window.

This change sets `StartupWMClass=com-fastmail-fastmail` in the `.desktop` file so COSMIC can match via that field.

Closes #23